### PR TITLE
Remove Python 3.10 from environment.yml and build_and_test.yml

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,4 +1,4 @@
-name: Build and test [Python 3.7, 3.8, 3.9, 3.10]
+name: Build and test [Python 3.7, 3.8, 3.9]
 
 on: [push, pull_request]
 
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, '3.10']
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
       - name: Checkout

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: ogusa-dev
 channels:
 - conda-forge
 dependencies:
-- python>=3.7.7
+- python>=3.7.7, <=3.9.12  # This restriction can be removed as soon as these packages support Python 3.10
 - mkl>=2020.2
 - numpy<=1.21.2  # This restriction can be removed as soon as Numba supports NumPy 1.22
 - psutil


### PR DESCRIPTION
@jdebacker It seems clear that from the error traceback in the current PR status that some of the packages we are using in OG-USA are not compatible with Python 3.10. This PR does the following:
1. Removes Python 3.10 from the `environment.yml` file. I added a maximum Python version of `python <=3.9.12`.
2. Removes Python 3.10 from the `build_and_test.yml` GitHub Actions.