### PR TITLE
Remove Python 3.7 tests

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,4 +1,4 @@
-name: Build and test [Python 3.7, 3.8, 3.9]
+name: Build and test [Python 3.8, 3.9]
 
 on: [push, pull_request]
 
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9]
 
     steps:
       - name: Checkout


### PR DESCRIPTION
@jdebacker. I recommend we remove the Python 3.7 tests from the `build_and_test.yaml` GitHub Action, as is done in this PR to your branch.