### PR TITLE
Demographics.py and build_and_test.yml

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
@@ -12,21 +12,23 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 
-      - name: Setup Python
-        uses: actions/setup-python@v4
+      - name: Setup Miniconda using Python ${{ matrix.python-version }}
+        uses: conda-incubator/setup-miniconda@v2
         with:
+          miniforge-variant: Mambaforge
+          auto-update-conda: true
+          activate-environment: ogusa-dev
+          environment-file: environment.yml
           python-version: ${{ matrix.python-version }}
+          auto-activate-base: false
 
       - name: Build
         shell: bash -l {0}
         run: |
-          conda init bash
-          conda env create
-          conda activate ogusa-dev
           pip install -e .
           pip install pytest-cov
           pip install pytest-pycodestyle

--- a/ogusa/demographics.py
+++ b/ogusa/demographics.py
@@ -152,25 +152,26 @@ def get_fert(
     #     pp.plot_fert_rates(fert_rates, age_midp, totpers, min_age, max_age,
     #                        fert_rates, fert_rates, output_dir=OUTPUT_DIR)
 
-    output_dir = OUTPUT_DIR
-    # Using pyplot here until update to OG-Core mort rates plotting function
-    plt.plot(
-        np.arange(totpers),
-        fert_rates,
-    )
-    plt.xlabel(r"Age $s$")
-    plt.ylabel(r"Fertility rate")
-    plt.legend(loc="upper left")
-    # plt.text(
-    #     -5,
-    #     -0.2,
-    #     "Source: United Nations Population Prospects.",
-    #     fontsize=9,
-    # )
-    plt.tight_layout(rect=(0, 0.03, 1, 1))
-    output_path = os.path.join(output_dir, "fert_rates")
-    plt.savefig(output_path)
-    plt.close()
+    if graph:
+        output_dir = OUTPUT_DIR
+        # Using pyplot here until update to OG-Core mort rates plotting function
+        plt.plot(
+            np.arange(totpers),
+            fert_rates,
+        )
+        plt.xlabel(r"Age $s$")
+        plt.ylabel(r"Fertility rate")
+        plt.legend(loc="upper left")
+        # plt.text(
+        #     -5,
+        #     -0.2,
+        #     "Source: United Nations Population Prospects.",
+        #     fontsize=9,
+        # )
+        plt.tight_layout(rect=(0, 0.03, 1, 1))
+        output_path = os.path.join(output_dir, "fert_rates")
+        plt.savefig(output_path)
+        plt.close()
 
     return fert_rates
 
@@ -182,7 +183,7 @@ def get_mort(
     country_id=UN_COUNTRY_CODE,
     start_year=START_YEAR,
     end_year=END_YEAR,
-    graph=True,
+    graph=False,
 ):
     """
     This function generates a vector of mortality rates by model period
@@ -297,6 +298,7 @@ def get_imm_rates(
     country_id=UN_COUNTRY_CODE,
     start_year=START_YEAR,
     end_year=END_YEAR,
+    graph=False,
 ):
     """
     Calculate immigration rates by age as a residual given population
@@ -380,26 +382,27 @@ def get_imm_rates(
     # Final estimated immigration rates are the averages over 3 years
     imm_rates = imm_mat.mean(axis=0)
 
-    output_dir = OUTPUT_DIR
-    # Using pyplot here until update to OG-Core mort rates plotting function
-    plt.plot(
-        np.arange(totpers),
-        imm_rates,
-        label="Estimated",
-    )
-    plt.xlabel(r"Age $s$")
-    plt.ylabel(r"Immigration Rates")
-    plt.legend(loc="upper left")
-    plt.text(
-        -5,
-        -0.2,
-        "Source: United Nations Population Prospects.",
-        fontsize=9,
-    )
-    plt.tight_layout(rect=(0, 0.03, 1, 1))
-    output_path = os.path.join(output_dir, "imm_rates_w_un_data.png")
-    plt.savefig(output_path)
-    plt.close()
+    if graph:
+        output_dir = OUTPUT_DIR
+        # Using pyplot here until update to OG-Core mort rates plotting function
+        plt.plot(
+            np.arange(totpers),
+            imm_rates,
+            label="Estimated",
+        )
+        plt.xlabel(r"Age $s$")
+        plt.ylabel(r"Immigration Rates")
+        plt.legend(loc="upper left")
+        plt.text(
+            -5,
+            -0.2,
+            "Source: United Nations Population Prospects.",
+            fontsize=9,
+        )
+        plt.tight_layout(rect=(0, 0.03, 1, 1))
+        output_path = os.path.join(output_dir, "imm_rates_w_un_data.png")
+        plt.savefig(output_path)
+        plt.close()
 
     return imm_rates
 


### PR DESCRIPTION
This PR:
- Updates `demographics.py`. The first test `test_get_pop_objs()` in `test_demographics.py` was failing because the `get_fert()`, `get_mort()`, and `get_imm_rates()` functions were defaulting to producing the plots. And the plot functions are not working correctly right now (See this [PR thread comment](https://github.com/PSLmodels/OG-USA/pull/73#issuecomment-1776560507)).
- Inserts the Mambaforge build approach into the build section of `build_and_test.yml`. I think this should help the CI move past that spot.

All the pytest tests pass for me locally after this PR.
```
(ogusa-dev) richardevans@Richards-MacBook-Pro-2 OG-USA % pytest
/opt/anaconda3/envs/ogusa-dev/lib/python3.11/site-packages/pep8.py:110: FutureWarning: Possible nested set at position 1
  EXTRANEOUS_WHITESPACE_REGEX = re.compile(r'[[({] | []}),;:]')
============================= test session starts ==============================
platform darwin -- Python 3.11.6, pytest-7.4.2, pluggy-1.3.0
rootdir: /Users/richardevans/Docs/Economics/OSE/OG-USA
configfile: pytest.ini
testpaths: ogusa/tests
plugins: xdist-3.3.1, pep8-1.0.6
collected 45 items                                                             

ogusa/tests/test_calibrate.py ....                                       [  8%]
ogusa/tests/test_demographics.py ........                                [ 26%]
ogusa/tests/test_get_micro_data.py ..............                        [ 57%]
ogusa/tests/test_income.py ............                                  [ 84%]
ogusa/tests/test_psid_data_setup.py ...                                  [ 91%]
ogusa/tests/test_run_example.py .                                        [ 93%]
ogusa/tests/test_utils.py .                                              [ 95%]
ogusa/tests/test_wealth.py ..                                            [100%]
================= 45 passed, 95 warnings in 2599.10s (0:43:19) =================
```

cc: @jdebacker 