### PR TITLE
Small OCD updates to your branch from Rick

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,7 +43,7 @@ docs/build*
 *micro_data_*.pkl
 examples/Example/*
 examples/Example-TMD/*
-examples/CP-Example/*
+examples/Example-CP/*
 cs-config/cs_config/OUTPUT_BASELINE/*
 data/csv_output_files/*
 data/images/*

--- a/examples/run_current_policy_baseline.py
+++ b/examples/run_current_policy_baseline.py
@@ -30,7 +30,7 @@ def main():
 
     # Directories to save data
     CUR_DIR = os.path.dirname(os.path.realpath(__file__))
-    save_dir = os.path.join(CUR_DIR, "CP-Example")
+    save_dir = os.path.join(CUR_DIR, "Example-CP")
     base_dir = os.path.join(save_dir, "OUTPUT_BASELINE")
     reform_dir = os.path.join(save_dir, "OUTPUT_REFORM")
 


### PR DESCRIPTION
@jdebacker. This PR:
- Updates the folder to which output gets saved (to `Example-CP`) in the `run_current_policy_baseline.py` run script. This makes that output folder inline with the other example output folders.
- Updates the `.gitignore` entry that ignores the above output.

I ran all the CI tests for this locally on my machine with a fresh `ogusa-dev` conda environment. This makes sure that the OG-Core changes work. However, it is interesting that my new conda environment uses Python 3.10.17. I wonder if that `marshmallow<4.0.0` restriction is not allowing us to get Python 3.11 and 3.12.
```
(ogusa-dev) richardevans@Richards-MacBook-Pro-5 OG-USA % pytest   
==================================== test session starts ====================================
platform darwin -- Python 3.10.17, pytest-8.3.5, pluggy-1.5.0
rootdir: /Users/richardevans/Docs/Economics/OSE/OG/OG-USA
configfile: pytest.ini
testpaths: ./tests
plugins: cov-6.1.1, xdist-3.6.1
collected 38 items                                                                          

tests/test_calibrate.py ....                                                          [ 10%]
tests/test_get_micro_data.py ...............                                          [ 50%]
tests/test_income.py ............                                                     [ 81%]
tests/test_psid_data_setup.py ...                                                     [ 89%]
tests/test_run_example.py .                                                           [ 92%]
tests/test_utils.py .                                                                 [ 94%]
tests/test_wealth.py ..                                                               [100%]

======================== 38 passed, 46 warnings in 538.55s (0:08:58) ========================

```